### PR TITLE
Migrate .zsh directory loading to sheldon

### DIFF
--- a/.config/sheldon/plugins.toml
+++ b/.config/sheldon/plugins.toml
@@ -25,3 +25,41 @@ github = "romkatv/powerlevel10k"
 github = "marlonrichert/zsh-autocomplete"
 [plugins.autosuggestions]
 github = "zsh-users/zsh-autosuggestions"
+
+# Local .zsh configuration files
+[plugins.local-completion]
+local = "~/.zsh"
+use = ["completion.zsh"]
+
+[plugins.local-alias]
+local = "~/.zsh"
+use = ["alias.zsh"]
+
+[plugins.local-brew]
+local = "~/.zsh"
+use = ["brew.zsh"]
+
+[plugins.local-fzf]
+local = "~/.zsh"
+use = ["fzf.zsh"]
+
+[plugins.local-p10k]
+local = "~/.zsh"
+use = ["p10k.zsh"]
+
+[plugins.local-scripts]
+local = "~/.zsh"
+use = ["scripts.zsh"]
+
+[plugins.local-ssh]
+local = "~/.zsh"
+use = ["ssh.zsh"]
+
+[plugins.local-tmux]
+local = "~/.zsh"
+use = ["tmux.zsh"]
+
+# Load local.zsh if it exists (not the .sample file)
+[plugins.local-custom]
+local = "~/.zsh"
+use = ["local.zsh"]

--- a/.zshrc
+++ b/.zshrc
@@ -74,15 +74,8 @@ path=(~/.scripts(N-/) $path)
 
 ZSH_HOME="${HOME}/.zsh"
 
-# 自作の.zshファイルを読み込み
-if [ -d $ZSH_HOME -a -r $ZSH_HOME -a -x $ZSH_HOME ]; then
-  for i in $ZSH_HOME/*; do
-    if [[ ${i##*/} = *.zsh ]] && [ \( -f $i -o -h $i \) -a -r $i ]; then
-      # echo "${i} を読み込みます。"
-      source $i
-    fi
-  done
-fi
+# sheldonを使用して.zshファイルとプラグインを読み込み
+eval "$(sheldon source)"
 
 if [[ ! -f "$ZSH_HOME/.zsh_history" ]]; then
   touch "$ZSH_HOME/.zsh_history"


### PR DESCRIPTION
This PR migrates the loading of .zsh configuration files from a manual loop in .zshrc to sheldon's local plugin feature.

## Changes
- Added local plugin entries in sheldon config for all .zsh files
- Replaced manual for-loop loading with sheldon source command
- Centralized plugin and configuration management

Closes #41

Generated with [Claude Code](https://claude.ai/code)